### PR TITLE
remove outline:0 from base css

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "bunn-design-system",
-	"version": "0.8.76",
+	"version": "0.8.77",
 	"description": "BUNN Design System",
 	"scripts": {
 		"dev": "cross-env ELEVENTY_ENV=development rm -rf dist && gulp dev",

--- a/resources/design-system/css/base/interactions.css
+++ b/resources/design-system/css/base/interactions.css
@@ -1,7 +1,7 @@
 a,
 a:visited,
 a:active {
-    outline: none;
+    /* outline: none; */
     text-decoration: none;
 }
 

--- a/resources/design-system/css/base/standard.css
+++ b/resources/design-system/css/base/standard.css
@@ -35,7 +35,7 @@ input, select {
 *:before,
 *:after {
     box-sizing: inherit;
-    outline: 0 !important;
+    /* outline: 0 !important; */
 }
 
 /* Remove bold from browser defaults */


### PR DESCRIPTION
Outlines are needed for accessibility concerns so a global reset of all outlines to 0 is unnecessary.